### PR TITLE
Handle Color32 variants

### DIFF
--- a/scripting/eventqueuefix.sp
+++ b/scripting/eventqueuefix.sp
@@ -4,7 +4,7 @@
 #define PLUGIN_NAME           "EventQueue fix"
 #define PLUGIN_AUTHOR         "carnifex"
 #define PLUGIN_DESCRIPTION    ""
-#define PLUGIN_VERSION        "1.3.2"
+#define PLUGIN_VERSION        "1.3.3"
 #define PLUGIN_URL            ""
 
 #include <sourcemod>
@@ -247,6 +247,13 @@ public void ResolveVariantValue(Handle &params, event_t event)
 		{
 			int iVar = DHookGetParamObjectPtrVar(params, 3, 0, ObjectValueType_Int);
 			IntToString(iVar, event.variantValue, sizeof(event.variantValue));
+		}
+		
+		//Color32
+		case 9:
+		{
+			int iVar = DHookGetParamObjectPtrVar(params, 3, 0, ObjectValueType_Int);
+			FormatEx(event.variantValue, sizeof(event.variantValue), "%d %d %d", (iVar&0xFF), (iVar&0xFF00) >> 8, (iVar&0xFF0000) >> 16);
 		}
 		
 		default:


### PR DESCRIPTION
With entities like `math_colorblend`, a `color32` value can be passed in non-string form. This shows up on `surf_classics` (CS:S) for example:
```
{
"origin" "-7872 14264 10048"
"targetname" "blend_1R"
"spawnflags" "1"
"inmax" "100"
"colormin" "255 255 255"
"colormax" "255 0 0 0"
"classname" "math_colorblend"
"hammerid" "37178"
"OutColor" "Brush_Color1,Color,,0,-1"
"OutColor" "Brush_Color2,Color,,0,-1"
"OutColor" "Brush_Color3,Color,,0,-1"
}
```
`Brush_Color` 1-3 are `func_brush` entities that receive the color.
You can go to the ramps at '-15122 15418 14992' to see the color changes (or the crash if you spawn in without using this PR).

I recall an unimportant map, with a sun entity, that crashed when using eventqueuefix, and it might also be color32 related. (I don't remember the map's name to check though)